### PR TITLE
Buf plugin for JetBrains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,10 @@ all:
 
 .PHONY: gen-proto
 gen-proto:
-	rm -rf idl/{google,grafeas,validate} || true
 	buf mod update idl
 	buf lint idl
 	buf format idl -w
 	buf generate idl
-	buf export buf.build/googleapis/googleapis -o idl
 
 .PHONY: gen-models
 gen-models:

--- a/idl/README.md
+++ b/idl/README.md
@@ -1,9 +1,5 @@
 Our protobufs use dependencies from the
 [Buf Schema Registry](https://buf.build/explore).
 
-You'll need to download these locally for your IDE to be happy.
-
-From the root-level of this repo, run:
-```
-buf export buf.build/googleapis/googleapis -o idl
-```
+To resolve the dependencies in any JetBrains editor (GoLand, IntelliJ), check
+out the official [plugin](https://plugins.jetbrains.com/plugin/19147-buf-for-protocol-buffers).


### PR DESCRIPTION
To index dependencies (e.g., googleapis) from the Buf CLI, we need to use this [JetBrains plugin](https://plugins.jetbrains.com/plugin/19147-buf-for-protocol-buffers).

Previously I was using `buf export` to pull them to resolve editor indexing on my local, but that was leading to linting errors.

It's much better to just let the plugin do its thing.