### PR TITLE
:books: New Tokei badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # api-go-template
 
 [![Lines Of Code](https://aschey.tech/tokei/github/kevinmichaelchen/api-go-template?category=code&style=for-the-badge)](https://github.com/kevinmichaelchen/api-go-template)
-[![Postgres](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
-[![forthebadge](https://forthebadge.com/images/badges/made-with-go.svg)](https://golang.org/)
-[![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)](https://forthebadge.com)
 
 A boilerplate Go repo that comes with:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Lines Of Code](https://aschey.tech/tokei/github/kevinmichaelchen/api-go-template?category=code&style=for-the-badge)](https://github.com/kevinmichaelchen/api-go-template)
 [![Postgres](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
-[![Go](https://img.shields.io/badge/--00ADD8?logo=go&logoColor=ffffff&style=for-the-badge)](https://golang.org/)
+[![forthebadge](https://forthebadge.com/images/badges/made-with-go.svg)](https://golang.org/)
+[![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)](https://forthebadge.com)
 
 A boilerplate Go repo that comes with:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # api-go-template
 
-[![Lines Of Code](https://tokei.rs/b1/github/kevinmichaelchen/api-go-template?category=code)](https://github.com/kevinmichaelchen/api-go-template)
+[![Lines Of Code](https://aschey.tech/tokei/github/kevinmichaelchen/api-go-template?category=code&style=for-the-badge)](https://github.com/kevinmichaelchen/api-go-template)
 
 A boilerplate Go repo that comes with:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # api-go-template
 
 [![Lines Of Code](https://aschey.tech/tokei/github/kevinmichaelchen/api-go-template?category=code&style=for-the-badge)](https://github.com/kevinmichaelchen/api-go-template)
-![](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)
+[![Postgres](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
+[![Go](https://img.shields.io/badge/--00ADD8?logo=go&logoColor=ffffff&style=for-the-badge)](https://golang.org/)
 
 A boilerplate Go repo that comes with:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # api-go-template
 
 [![Lines Of Code](https://aschey.tech/tokei/github/kevinmichaelchen/api-go-template?category=code&style=for-the-badge)](https://github.com/kevinmichaelchen/api-go-template)
+![](https://img.shields.io/badge/PostgreSQL-316192?style=for-the-badge&logo=postgresql&logoColor=white)
 
 A boilerplate Go repo that comes with:
 


### PR DESCRIPTION
New README — https://github.com/kevinmichaelchen/api-go-template/blob/tokei-badge-update/README.md

The tokei.rs server goes down from time to time. Running on Vercel with caching on the edge (thanks to https://github.com/aschey/vercel-tokei) seems more performant and reliable.

Also added a few other badges — from [here](https://github.com/alexandresanlim/Badges4-README.md-Profile) and [here](https://forthebadge.com/).